### PR TITLE
Allow specifying the version name with Renv install

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,13 @@ the exact name of the version you want to install. For example,
 
     $ Renv install 2.15.2
 
-R versions will be installed into a directory of the same name
-under `~/.Renv/versions`.
+installs R version 2.15.2 to `~/.Renv/versions/2.15.2`. Provide an
+additional argument to install to a directory with a name that differs
+from the version number. For example,
+
+    $ Renv install 2.15.2 my-proj
+
+installs R version 2.15.2 to `~/.Renv/versions/my-proj`.
 
 To see a list of all available R versions, run `Renv install`
 without any arguments. You may also tab-complete available R

--- a/bin/Renv-install
+++ b/bin/Renv-install
@@ -15,7 +15,7 @@ fi
 eval "$(R-build --lib)"
 
 usage() {
-  { echo "usage: Renv install [-k|--keep] [-v|--verbose] VERSION"
+  { echo "usage: Renv install [-k|--keep] [-v|--verbose] VERSION [VERSION_NAME]"
     echo "       Renv install [-k|--keep] [-v|--verbose] /path/to/definition"
     echo "       Renv install -l|--list"
     echo
@@ -61,11 +61,15 @@ done
 DEFINITION="${ARGUMENTS[0]}"
 [ -n "$DEFINITION" ] || usage 1
 
+VERSION_NAME="${ARGUMENTS[1]}"
+
 for script in $(Renv-hooks install); do
   source "$script"
 done
 
-VERSION_NAME="${DEFINITION##*/}"
+if [ -z "$VERSION_NAME" ]; then
+    VERSION_NAME="${DEFINITION##*/}"
+fi
 PREFIX="${RENV_ROOT}/versions/${VERSION_NAME}"
 
 # If RENV_BUILD_ROOT is set, then always pass keep options to R-build


### PR DESCRIPTION
Currently, when using Renv install, the name of the version stored in ~/.Renv/versions is taken from the version number, such as 3.2.3. This adds support for changing the version name. This is useful when creating versions for different projects, where you might want the same version number but want to isolate the packages installed into those versions.

This feature is already available when running R-build as a standalone program. Here, I'm adding the feature to R-build when called as an Renv plugin.